### PR TITLE
Polyfill with axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "vite-sample-app",
   "private": true,
   "scripts": {
-    "build": "vite build && vite preview --port 4173"
+    "build": "vite build && vite preview --port 4173",
+    "dev": "vite"
   },
   "dependencies": {
+    "axios": "^1.7.4",
     "monero-ts": "^0.10.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ async function testSampleCode() {
         at async T.getHeight (index.js:496:42372)
         at async tA (index.js:505:106455) */
   // connect to mainnet daemon without worker proxy
-  let daemon1 = await moneroTs.connectToDaemonRpc({server: "https://node.sethforprivacy.com:18089", proxyToWorker: false});
+  let daemon1 = await moneroTs.connectToDaemonRpc({server: "https://moneronode.org:18081", proxyToWorker: false});
   console.log("Daemon height 1: " + await daemon1.getHeight());
 
   // TODO: get failures in the browser using web worker: "fetch is not a function"
@@ -39,7 +39,7 @@ async function testSampleCode() {
         at e.exports.<anonymous> (monero_web_worker.js:2:1542602)
         at a.emit (monero_web_worker.js:2:1007398) */
   // connect to mainnet daemon with worker proxy
-  let daemon2 = await moneroTs.connectToDaemonRpc({server: "https://node.sethforprivacy.com:18089", proxyToWorker: true});
+  let daemon2 = await moneroTs.connectToDaemonRpc({server: "https://moneronode.org:18081", proxyToWorker: true});
   console.log("Daemon height 2: " + await daemon2.getHeight());
 
   // connect to a daemon

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,15 +94,21 @@ export default defineConfig({
             };
 
             const Request = function(opts) {
-              const normalizedOpts = normalizeOptions(opts);
-              return axios(normalizedOpts)
-                .then(response => {
-                  if (opts.resolveWithFullResponse) {
-                    return response;
-                  }
-                  return response.data;
-                });
-            };
+        const normalizedOpts = normalizeOptions(opts);
+        return axios(normalizedOpts)
+          .then(response => {
+            if (opts.resolveWithFullResponse) {
+              // If full response is requested, return a response-like object
+              return {
+                statusCode: response.status,
+                headers: response.headers,
+                body: JSON.stringify(response.data)
+              };
+            }
+            // Otherwise, just return the response data as text
+            return JSON.stringify(response.data);
+          });
+      };
 
             const methodFactory = (method) => {
               return (url, opts = {}) => Request({ ...opts, method, url });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,72 +1,7 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
-
 import { copyFileSync } from "fs";
 import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
-interface RequestPromiseOptions extends AxiosRequestConfig {
-  simple?: boolean;
-  resolve?: (value: any) => void;
-  reject?: (reason: any) => void;
-}
-
-interface RequestPromiseAPI {
-  (options: RequestPromiseOptions): Promise<any>;
-  (url: string): Promise<any>;
-  get(url: string, options?: RequestPromiseOptions): Promise<any>;
-  post(url: string, options?: RequestPromiseOptions): Promise<any>;
-  put(url: string, options?: RequestPromiseOptions): Promise<any>;
-  patch(url: string, options?: RequestPromiseOptions): Promise<any>;
-  del(url: string, options?: RequestPromiseOptions): Promise<any>;
-  delete(url: string, options?: RequestPromiseOptions): Promise<any>;
-  head(url: string, options?: RequestPromiseOptions): Promise<any>;
-  options(url: string, options?: RequestPromiseOptions): Promise<any>;
-  default(url: string, options?: RequestPromiseOptions): Promise<any>;
-
-}
-
-const createRequestPromisePolyfill = `
-(axios) => {
-  const requestPromise = ((options) => {
-    let axiosOptions = {};
-    
-    if (typeof options === 'string') {
-      axiosOptions.url = options;
-    } else {
-      axiosOptions = { ...options };
-    }
-
-    return new Promise((resolve, reject) => {
-      axios(axiosOptions)
-        .then(response => {
-          if (options.simple !== false || (response.status >= 200 && response.status < 300)) {
-            resolve(response.data);
-          } else {
-            reject(new Error(\`Request failed with status code \${response.status}\`));
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
-    });
-  });
-
-  const methodFactory = (method) => {
-    return (url, options = {}) => {
-      return requestPromise({ ...options, url, method });
-    };
-  };
-
-  requestPromise.get = methodFactory('get');
-  requestPromise.post = methodFactory('post');
-  requestPromise.put = methodFactory('put');
-  requestPromise.patch = methodFactory('patch');
-  requestPromise.del = requestPromise.delete = methodFactory('delete');
-  requestPromise.head = methodFactory('head');
-  requestPromise.options = methodFactory('options');
-
-  return requestPromise;
-}`;
 export default defineConfig({
   plugins: [
     nodePolyfills({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,83 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+
 import { copyFileSync } from "fs";
 import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
+interface RequestPromiseOptions extends AxiosRequestConfig {
+  simple?: boolean;
+  resolve?: (value: any) => void;
+  reject?: (reason: any) => void;
+}
+
+interface RequestPromiseAPI {
+  (options: RequestPromiseOptions): Promise<any>;
+  (url: string): Promise<any>;
+  get(url: string, options?: RequestPromiseOptions): Promise<any>;
+  post(url: string, options?: RequestPromiseOptions): Promise<any>;
+  put(url: string, options?: RequestPromiseOptions): Promise<any>;
+  patch(url: string, options?: RequestPromiseOptions): Promise<any>;
+  del(url: string, options?: RequestPromiseOptions): Promise<any>;
+  delete(url: string, options?: RequestPromiseOptions): Promise<any>;
+  head(url: string, options?: RequestPromiseOptions): Promise<any>;
+  options(url: string, options?: RequestPromiseOptions): Promise<any>;
+  default(url: string, options?: RequestPromiseOptions): Promise<any>;
+
+}
+
+const createRequestPromisePolyfill = `
+(axios) => {
+  const requestPromise = ((options) => {
+    let axiosOptions = {};
+    
+    if (typeof options === 'string') {
+      axiosOptions.url = options;
+    } else {
+      axiosOptions = { ...options };
+    }
+
+    return new Promise((resolve, reject) => {
+      axios(axiosOptions)
+        .then(response => {
+          if (options.simple !== false || (response.status >= 200 && response.status < 300)) {
+            resolve(response.data);
+          } else {
+            reject(new Error(\`Request failed with status code \${response.status}\`));
+          }
+        })
+        .catch(error => {
+          reject(error);
+        });
+    });
+  });
+
+  const methodFactory = (method) => {
+    return (url, options = {}) => {
+      return requestPromise({ ...options, url, method });
+    };
+  };
+
+  requestPromise.get = methodFactory('get');
+  requestPromise.post = methodFactory('post');
+  requestPromise.put = methodFactory('put');
+  requestPromise.patch = methodFactory('patch');
+  requestPromise.del = requestPromise.delete = methodFactory('delete');
+  requestPromise.head = methodFactory('head');
+  requestPromise.options = methodFactory('options');
+
+  return requestPromise;
+}`;
 export default defineConfig({
   plugins: [
-    nodePolyfills({ include: ["http", "https", "fs"] }),
+    nodePolyfills({
+      include: ["http", "https", "fs"],
+      globals: {
+        Buffer: true,
+        global: true,
+        process: true,
+      },
+      // protocolImports: true,
+    }),
     {
       name: "copy-files",
       writeBundle: () =>
@@ -26,6 +99,93 @@ export default defineConfig({
           ? src.replaceAll("require.cache", "null")
           : src,
     },
+    {
+      name: 'request-promise-polyfill',
+      config() {
+        return {
+          resolve: {
+            alias: {
+              'request-promise': 'virtual:request-promise-polyfill',
+            },
+          },
+        };
+      },
+      resolveId(id: string) {
+        if (id === 'virtual:request-promise-polyfill') {
+          return id;
+        }
+      },
+      load(id: string) {
+        if (id === 'virtual:request-promise-polyfill') {
+          return `
+            import axios from 'axios';
+            import { URL } from 'url';
+
+            const normalizeOptions = (input) => {
+              let opts = typeof input === 'string' ? { url: input } : { ...input };
+              
+              if (opts.uri) {
+                opts.url = opts.uri;
+                delete opts.uri;
+              }
+
+              if (!opts.url && opts.baseUrl) {
+                opts.url = opts.baseUrl;
+                delete opts.baseUrl;
+              }
+
+              if (opts.qs) {
+                const url = new URL(opts.url);
+                Object.entries(opts.qs).forEach(([key, value]) => {
+                  url.searchParams.append(key, value);
+                });
+                opts.url = url.toString();
+                delete opts.qs;
+              }
+
+              if (opts.form) {
+                opts.data = opts.form;
+                opts.headers = opts.headers || {};
+                opts.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                delete opts.form;
+              }
+
+              if (opts.body) {
+                opts.data = opts.body;
+                delete opts.body;
+              }
+
+              return opts;
+            };
+
+            const Request = function(opts) {
+              const normalizedOpts = normalizeOptions(opts);
+              return axios(normalizedOpts)
+                .then(response => {
+                  if (opts.resolveWithFullResponse) {
+                    return response;
+                  }
+                  return response.data;
+                });
+            };
+
+            const methodFactory = (method) => {
+              return (url, opts = {}) => Request({ ...opts, method, url });
+            };
+
+            Request.get = methodFactory('get');
+            Request.post = methodFactory('post');
+            Request.put = methodFactory('put');
+            Request.patch = methodFactory('patch');
+            Request.delete = methodFactory('delete');
+            Request.head = methodFactory('head');
+            Request.options = methodFactory('options');
+
+            export default Request;
+          `;
+        }
+      },
+    },
   ],
   build: {
     outDir: "dist",
@@ -38,5 +198,8 @@ export default defineConfig({
         format: "es",
       },
     },
+  },
+  optimizeDeps: {
+    include: ["axios"],
   },
 });


### PR DESCRIPTION
Fix https://github.com/woodser/monero-ts/issues/229

Request-Promise and Request libraries are deprecated so I polyfilled with axios to escape using them
A more permanent solution will be to rewrite the implementation in monero-ts to use something like axios